### PR TITLE
move from the `dfu` library to `dfu-libusb`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,6 +36,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84450d0b4a8bd1ba4144ce8ce718fbc5d071358b1e5384bace6536b3d1f2d5b3"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -74,12 +80,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
+name = "bytes"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
+
+[[package]]
 name = "cargo-dfu"
 version = "0.0.4"
 dependencies = [
  "cargo-project",
  "colored",
- "dfu",
+ "dfu-libusb",
  "goblin",
  "log",
  "maplit",
@@ -155,16 +167,59 @@ dependencies = [
 ]
 
 [[package]]
-name = "dfu"
-version = "0.4.2"
+name = "console"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb1d1eb7e47b3cba338775698712a8cb285aa15d45e58329c59411a55fbc1b98"
+checksum = "a28b32d32ca44b70c3e4acd7db1babf555fa026e385fb95f18028f88848b3c31"
 dependencies = [
- "log",
- "nix",
- "serde",
- "usbapi",
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "terminal_size",
+ "winapi",
 ]
+
+[[package]]
+name = "dfu-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2ad086a5a9b918afe8423e8a858998b48cdd3fceb0f67ce20eab7bc46d8b6ee"
+dependencies = [
+ "bytes",
+ "displaydoc",
+ "thiserror",
+]
+
+[[package]]
+name = "dfu-libusb"
+version = "0.1.0"
+source = "git+https://github.com/dfu-rs/dfu-libusb.git?rev=84d05c366671bc2608c8d2b68fe79a67a327d3a3#84d05c366671bc2608c8d2b68fe79a67a327d3a3"
+dependencies = [
+ "anyhow",
+ "dfu-core",
+ "indicatif",
+ "libusb1-sys",
+ "rusb",
+ "structopt",
+ "thiserror",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bf95dc3f046b9da4f2d51833c0d3547d8564ef6910f5c1ed130306a75b92886"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "encode_unicode"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "env_logger"
@@ -252,6 +307,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicatif"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d207dc617c7a380ab07ff572a6e52fa202a2a8f355860ac9c38e23f8196be1b"
+dependencies = [
+ "console",
+ "lazy_static",
+ "number_prefix",
+ "regex",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -297,15 +364,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
-name = "memoffset"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59accc507f1338036a0477ef61afdae33cde60840f4dfe481319ce3ad116ddf9"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "miniz_oxide"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -313,19 +371,6 @@ checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
 dependencies = [
  "adler",
  "autocfg",
-]
-
-[[package]]
-name = "nix"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5e06129fb611568ef4e868c14b326274959aa70ff7776e9d55323531c374945"
-dependencies = [
- "bitflags",
- "cc",
- "cfg-if",
- "libc",
- "memoffset",
 ]
 
 [[package]]
@@ -348,6 +393,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
+
+[[package]]
 name = "object"
 version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -355,6 +406,12 @@ checksum = "67ac1d3f9a1d3616fd9a60c8d74296f22406a238b6a72f5cc1e6f314df4ffbf9"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da32515d9f6e6e489d7bc9d84c71b060db7247dc035bbe44eac88cf87486d8d5"
 
 [[package]]
 name = "pkg-config"
@@ -494,9 +551,6 @@ name = "serde"
 version = "1.0.130"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f12d06de37cf59146fbdecab66aa99f9fe4f78722e3607577a5375d66bd0c913"
-dependencies = [
- "serde_derive",
-]
 
 [[package]]
 name = "serde_derive"
@@ -563,15 +617,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sysfs-serde"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95eb4a78bc7d9d0bbc4a4cd2f5d2756e67e27a4d11bb52df6406508dae15066a"
-dependencies = [
- "log",
-]
-
-[[package]]
 name = "termcolor"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -581,12 +626,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "terminal_size"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
  "unicode-width",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "854babe52e4df1653706b98fcfc05843010039b406875930a70e4d9644e5c417"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -626,18 +701,6 @@ name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
-
-[[package]]
-name = "usbapi"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc33ce833e969eaf16937f8ec81bd10e52428159e4d45dd3d70b0c0f6558e416"
-dependencies = [
- "libc",
- "log",
- "nix",
- "sysfs-serde",
-]
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,12 +36,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.52"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84450d0b4a8bd1ba4144ce8ce718fbc5d071358b1e5384bace6536b3d1f2d5b3"
-
-[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -167,23 +161,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "console"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28b32d32ca44b70c3e4acd7db1babf555fa026e385fb95f18028f88848b3c31"
-dependencies = [
- "encode_unicode",
- "libc",
- "once_cell",
- "terminal_size",
- "winapi",
-]
-
-[[package]]
 name = "dfu-core"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2ad086a5a9b918afe8423e8a858998b48cdd3fceb0f67ce20eab7bc46d8b6ee"
+checksum = "3b82ffc1790e4af9371dbc3399c6c068a3ee506357632e21eb7111df199c59f3"
 dependencies = [
  "bytes",
  "displaydoc",
@@ -192,15 +173,13 @@ dependencies = [
 
 [[package]]
 name = "dfu-libusb"
-version = "0.1.0"
-source = "git+https://github.com/dfu-rs/dfu-libusb.git?rev=84d05c366671bc2608c8d2b68fe79a67a327d3a3#84d05c366671bc2608c8d2b68fe79a67a327d3a3"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c2092d59a31cc15f8e9a916ff6b020a0fe794b1ec8626d08eefeb7ad2bcb8f7"
 dependencies = [
- "anyhow",
  "dfu-core",
- "indicatif",
  "libusb1-sys",
  "rusb",
- "structopt",
  "thiserror",
 ]
 
@@ -214,12 +193,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "encode_unicode"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "env_logger"
@@ -307,18 +280,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indicatif"
-version = "0.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d207dc617c7a380ab07ff572a6e52fa202a2a8f355860ac9c38e23f8196be1b"
-dependencies = [
- "console",
- "lazy_static",
- "number_prefix",
- "regex",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -393,12 +354,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "number_prefix"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
-
-[[package]]
 name = "object"
 version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -406,12 +361,6 @@ checksum = "67ac1d3f9a1d3616fd9a60c8d74296f22406a238b6a72f5cc1e6f314df4ffbf9"
 dependencies = [
  "memchr",
 ]
-
-[[package]]
-name = "once_cell"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da32515d9f6e6e489d7bc9d84c71b060db7247dc035bbe44eac88cf87486d8d5"
 
 [[package]]
 name = "pkg-config"
@@ -623,16 +572,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
 dependencies = [
  "winapi-util",
-]
-
-[[package]]
-name = "terminal_size"
-version = "0.1.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
-dependencies = [
- "libc",
- "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,4 +22,7 @@ cargo-project = "0.2.4"
 structopt = "0.3.2"
 maplit = "1.0.2"
 log = "0.4.6"
-dfu = "0.4"
+
+[dependencies.dfu-libusb]
+git = "https://github.com/dfu-rs/dfu-libusb.git"
+rev = "84d05c366671bc2608c8d2b68fe79a67a327d3a3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,4 @@ cargo-project = "0.2.4"
 structopt = "0.3.2"
 maplit = "1.0.2"
 log = "0.4.6"
-
-[dependencies.dfu-libusb]
-git = "https://github.com/dfu-rs/dfu-libusb.git"
-rev = "84d05c366671bc2608c8d2b68fe79a67a327d3a3"
+dfu-libusb = "0.2.0"

--- a/Readme.md
+++ b/Readme.md
@@ -49,5 +49,4 @@ sudo cp udev.rules /etc/udev/rules.d/cargo-dfu.rules
 ```
 
 ## Roadmap
-- [ ] make this crate multi-platform (PR to either the dfu crate to use rusb or the usbapi to add platform support)
 - [ ] check if multiple chips are connected 

--- a/src/main.rs
+++ b/src/main.rs
@@ -137,14 +137,12 @@ fn main() {
 
     println!("    {} {:?}", "Flashing".green().bold(), path);
 
-    let (binary, address) = elf_to_bin(path).unwrap();
+    let (binary, _) = elf_to_bin(path).unwrap();
 
     // Start timer.
     let instant = Instant::now();
 
-    // let bininfo = hf2::bin_info(&d).expect("bin_info failed");
-    // log::debug!("{:?}", bininfo);
-    flash_bin(&binary, address, &d.device()).unwrap();
+    flash_bin(&binary, &d.device()).unwrap();
 
     // Stop timer.
     let elapsed = instant.elapsed();

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -54,11 +54,7 @@ pub fn elf_to_bin(path: PathBuf) -> Result<(Vec<u8>, u32), UtilError> {
     Ok((data, start_address as u32))
 }
 
-pub fn flash_bin(
-    binary: &[u8],
-    address: u32,
-    d: &rusb::Device<GlobalContext>,
-) -> Result<(), UtilError> {
+pub fn flash_bin(binary: &[u8], d: &rusb::Device<GlobalContext>) -> Result<(), UtilError> {
     let mut dfu = dfu_libusb::DfuLibusb::open(
         &rusb::Context::new().unwrap(),
         d.device_descriptor().unwrap().vendor_id(),


### PR DESCRIPTION
This makes the crate usable for people with operating systems that aren't linux.